### PR TITLE
Fix: Run on PRs from forked repositories

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ case "${GITHUB_EVENT_NAME}" in
     done
     ;;
 
-'pull_request')
+'pull_request' | 'pull_request_target')
     label=$(jq -r ".pull_request.labels[].name | select(test(\"$prefix(major|minor|patch)\"))" "${GITHUB_EVENT_PATH}")
     ;;
 


### PR DESCRIPTION
This action currently does not run when a pull request is made from a fork of the repository.

This PR fixes the issue. [[Ref](https://docs.github.com/en/enterprise-server@3.0/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target)]